### PR TITLE
Example testing a macro within a local dbt project

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,0 +1,3 @@
+name: 'generic_test_demo'
+version: '0.1.0'
+config-version: 2

--- a/macros/custom_not_null.sql
+++ b/macros/custom_not_null.sql
@@ -1,0 +1,7 @@
+{% test custom_not_null(model, column_name) %}
+
+    select *
+    from {{ model }}
+    where {{ column_name }} is null
+
+{% endtest %}

--- a/tests/functional/example/fixture_model_unit_test.py
+++ b/tests/functional/example/fixture_model_unit_test.py
@@ -1,0 +1,23 @@
+# seeds/upstream_model_1.csv
+upstream_model_1 = """
+id,name,some_date
+1,Easton,1981-05-20T06:46:51
+2,Lillian,1978-09-03T18:10:33
+3,Jeremiah,1982-03-11T03:59:51
+""".lstrip()
+
+# seeds/upstream_model_2.csv
+upstream_model_2 = """
+id,favorite_color
+1,red
+2,green
+3,blue
+""".lstrip()
+
+# seeds/expected.csv
+expected = """
+id,name,favorite_color
+1,Easton,red
+2,Lillian,green
+3,Jeremiah,blue
+""".lstrip()

--- a/tests/functional/example/fixtures.py
+++ b/tests/functional/example/fixtures.py
@@ -22,6 +22,5 @@ models:
     columns:
       - name: id
         tests:
-          - unique
-          - not_null  # this test will fail
+          - generic_test_demo.custom_not_null  # this test will fail
 """

--- a/tests/my_test.sql
+++ b/tests/my_test.sql
@@ -1,0 +1,5 @@
+-- This model is defined here:
+--   tests/functional/example/fixtures.py
+select *
+from {{ ref('my_model' )}}
+where id is null


### PR DESCRIPTION
## Background
A dbt project can contain macros like [custom generic tests](https://docs.getdbt.com/docs/building-a-dbt-project/tests#generic-tests) and SQL files like [custom singular tests](https://docs.getdbt.com/docs/building-a-dbt-project/tests#singular-tests). How do you know if they work correctly for the edge cases of possible input?

This branch demonstrates how to use `pytest` to interrogate that these custom tests behave as expected.

### Note
This is only intended to show how to use the testing framework -- it doesn't cover all the test cases you'd want and expect.

## Running the tests
```shell
# all tests
python3 -m pytest

# example of a generic test (aka "custom data test")
python3 -m pytest tests/functional/example/test_example_failing_test.py::TestGenericTestExample

# example of a singular test (aka "custom schema test")
python3 -m pytest tests/functional/example/test_example_failing_test.py::TestSingularTestExample

# example of a test for the transformation of a single model
python3 -m pytest tests/functional/example/test_example_failing_test.py::TestModelBuildExample
```